### PR TITLE
fix: smms uploader `format` field

### DIFF
--- a/extensions/smms.jsonc
+++ b/extensions/smms.jsonc
@@ -18,7 +18,7 @@
             "body": {
                 "format": {
                     "type": "string",
-                    "value": "$(task.targetPath)"
+                    "value": "json"
                 },
                 "smfile": {
                     "type": "file",


### PR DESCRIPTION
https://doc.sm.ms/#api-Image-Upload

`format` should be `json` .