### PR TITLE
fix: correct sucessfully to successfully typo in upload log messages

### DIFF
--- a/lib/qcloudcos/uploader.go
+++ b/lib/qcloudcos/uploader.go
@@ -45,7 +45,7 @@ func (u COSUploader) Upload(t *model.Task) error {
 	// var err error
 	err := u.PutFile(t.LocalPath, targetPath)
 	if err == nil {
-		xlog.GVerbose.Info("sucessfully uploaded #TASK_%d %s => %s\n", t.TaskId, t.LocalPath, url)
+		xlog.GVerbose.Info("successfully uploaded #TASK_%d %s => %s\n", t.TaskId, t.LocalPath, url)
 		t.Status = model.TASK_FINISHED
 		t.Url = url
 		t.FinishTime = time.Now()

--- a/lib/uploaders/github_upload.go
+++ b/lib/uploaders/github_upload.go
@@ -88,7 +88,7 @@ func (u GithubUploader) Upload(t *model.Task) error {
 	// var err error
 	err := u.PutFile("upload "+base+" via upgit client", t.LocalPath, targetPath)
 	if err == nil {
-		xlog.GVerbose.Info("sucessfully uploaded #TASK_%d %s => %s\n", t.TaskId, t.LocalPath, url)
+		xlog.GVerbose.Info("successfully uploaded #TASK_%d %s => %s\n", t.TaskId, t.LocalPath, url)
 	} else {
 		xlog.GVerbose.Info("failed to upload #TASK_%d %s : %s\n", t.TaskId, t.LocalPath, err.Error())
 	}

--- a/lib/uploaders/simple_http_uploader.go
+++ b/lib/uploaders/simple_http_uploader.go
@@ -286,7 +286,7 @@ func (u SimpleHttpUploader) Upload(t *model.Task) (err error) {
 	var url string
 	if err == nil {
 		url := xapp.ReplaceUrl(rawUrl)
-		xlog.GVerbose.Trace("sucessfully uploaded #TASK_%d %s => %s\n", t.TaskId, t.LocalPath, url)
+		xlog.GVerbose.Trace("successfully uploaded #TASK_%d %s => %s\n", t.TaskId, t.LocalPath, url)
 		t.Status = model.TASK_FINISHED
 	} else {
 		xlog.GVerbose.Trace("failed to upload #TASK_%d %s : %s\n", t.TaskId, t.LocalPath, err.Error())

--- a/lib/upyun/uploader.go
+++ b/lib/upyun/uploader.go
@@ -39,7 +39,7 @@ func (u UpyunUploader) Upload(t *model.Task) error {
 	// var err error
 	err := u.PutFile(t.LocalPath, targetPath)
 	if err == nil {
-		xlog.GVerbose.Info("sucessfully uploaded #TASK_%d %s => %s\n", t.TaskId, t.LocalPath, url)
+		xlog.GVerbose.Info("successfully uploaded #TASK_%d %s => %s\n", t.TaskId, t.LocalPath, url)
 		t.Status = model.TASK_FINISHED
 		t.Url = url
 		t.FinishTime = time.Now()


### PR DESCRIPTION
## Summary
Corrects the typo `sucessfully` → `successfully` in upload log messages across 4 files.

## Changes
- `lib/upyun/uploader.go` line 42
- `lib/uploaders/github_upload.go`
- `lib/uploaders/simple_http_uploader.go`
- `lib/qcloudcos/uploader.go`

## Testing
- Build verified with go build